### PR TITLE
[fix]: ensure internal traces get dropped

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -323,6 +323,9 @@ function setSamplingRate(ddSpanBase: typeof Span, span: ReadableSpan): void {
   const internalRequest = isInternalRequest(span);
 
   if (internalRequest) {
+    // TODO: add more robust way to drop internal requests
+    ddSpanBase.context()._traceFlags.sampled = false;
+    ddSpanBase.context()._sampling.priority = DatadogSamplingCodes.USER_REJECT;
     ddSpanBase.setTag(
       DatadogDefaults.SAMPLE_RATE_METRIC_KEY,
       DatadogSamplingCodes.USER_REJECT


### PR DESCRIPTION
Setting sample rate tag to -1 isn't causing the internal requests to the datadog agent to get dropped. While investigating, add fix so these have a sampling rate set to -1.